### PR TITLE
Add i18n support for warning screen messages

### DIFF
--- a/components/warning_screen/warning_screen.ejs
+++ b/components/warning_screen/warning_screen.ejs
@@ -1,19 +1,10 @@
 <div class="warning_screen" id="warning_screen" style="display: none;">
     <div class="warning_card">
         <img src="icons/warning.svg" alt="warning icon">
-        <p>
-            Para una mejor experiencia, se recomienda jugar con auriculares.
-            Esto permitirá disfrutar plenamente de la ambientación, los efectos de sonido y la inmersión
-        </p>
+        <p data-i18n="warning.headphones"></p>
     </div>
     <div class="warning_card">
         <img src="icons/headphone.svg" alt="headphone icon">
-        <p>
-            Este juego ha sido diseñado para ofrecer una experiencia inmersiva e intensa. 
-            Durante la partida vas a encontrarte con: <br><br>
-            Luces intermitentes y destellos repentinos <br>
-            Sonidos fuertes, estridentes y sobresaltos inesperados <br>
-            Escenas que pueden generar tensión, miedo o ansiedad
-        </p>
+        <p data-i18n="warning.intenseExperience"></p>
     </div>
 </div>

--- a/public/lang/en.json
+++ b/public/lang/en.json
@@ -37,5 +37,9 @@
       "Chica": "Chica advances leaving a trail of metal and creaks.\nEach sound announces a hunger that never rests.\nIgnoring those noises opens the door to your end.",
       "Foxy": "Foxy waits behind the curtain, restless and fierce.\nWhen he runs, no refuge is possible.\nKeeping his cove under watch is the only truce."
     }
+  },
+  "warning":{
+    "headphones": "For the best experience, it is recommended to play with headphones. This will allow you to fully enjoy the atmosphere, sound effects, and immersion",
+    "intenseExperience": "This game is designed to provide an immersive and intense experience. During gameplay, you will encounter: Flashing lights and sudden flashes Loud, piercing sounds and unexpected jumpscares Scenes that may generate tension, fear, or anxiety"
   }
 }

--- a/public/lang/es.json
+++ b/public/lang/es.json
@@ -37,5 +37,9 @@
       "Chica": "Chica avanza dejando un rastro de metales y crujidos.\nCada sonido anuncia un hambre que nunca se sacia.\nQuien ignora esos ruidos, abre la puerta a su final.",
       "Foxy": "Foxy espera tras la cortina, impaciente y feroz.\nCuando corre, no hay refugio posible.\nMantener su guarida bajo vigilancia es la única tregua."
     }
+  },
+  "warning":{
+    "headphones": "Para una mejor experiencia, se recomienda jugar con auriculares. Esto permitirá disfrutar plenamente de la ambientación, los efectos de sonido y la inmersión",
+    "intenseExperience": "Este juego ha sido diseñado para ofrecer una experiencia inmersiva e intensa. Durante la partida vas a encontrarte con: Luces intermitentes y destellos repentinos Sonidos fuertes, estridentes y sobresaltos inesperados Escenas que pueden generar tensión, miedo o ansiedad"
   }
 }


### PR DESCRIPTION
## Summary
This PR introduces internationalization support for the warning screen by replacing hardcoded text with i18n keys and adding the corresponding translations in **both English and Spanish**.

## Changes
- Updated `warning_screen` HTML:
  - Replaced static `<p>` text with `data-i18n` attributes (`warning.headphones`, `warning.intenseExperience`).
- Extended the i18n JSON files:
  - **English (en.json):**
    - Added `warning.headphones`
    - Added `warning.intenseExperience`
  - **Spanish (es.json):**
    - Added `warning.headphones`
    - Added `warning.intenseExperience`

## Motivation
Previously, the warning screen displayed only static Spanish text, making localization impossible.  
With this change, the game now supports multiple languages for these messages, improving accessibility and consistency.

## Related Issues
Closes #17 
