### PR TITLE
feat: handle battery depletion with Freddy-only game over

### DIFF
--- a/public/js/HUD.js
+++ b/public/js/HUD.js
@@ -22,10 +22,10 @@ export default class HUD {
       this.battery = Math.max(0, this.battery - 1);
       this._updateUI();
 
-      if (this.battery === 0) {
-        clearInterval(this.batteryInterval);
-        this.game.setState(this.game.GAME_STATES.GAME_OVER);
-      }
+      //if (this.battery === 0) {
+      //  clearInterval(this.batteryInterval);
+      //  this.game.setState(this.game.GAME_STATES.GAME_OVER);
+      //}
     }, 10000); // baja 1% cada 10s
   }
 
@@ -113,10 +113,15 @@ export default class HUD {
         this._gameOverTriggered = true; // flag para no repetir
         clearInterval(this.batteryInterval); // parar consumo
 
+        this.game.onlyFreddyActive = true;
+
+        // aca iria la animacion de sonido
+
         // ⏳ esperar 3 segundos antes del GAME_OVER
         this.gameOverTimeout = setTimeout(() => {
+          this.game.showGameOver("Freddy");
           this.game.setState(this.game.GAME_STATES.GAME_OVER);
-        }, 50000);
+        }, 10000);
       }
     } else {
       this.batteryON.style.display = "block";

--- a/public/js/animatronics.js
+++ b/public/js/animatronics.js
@@ -82,6 +82,10 @@ export function startAnimatronics(gameInstance, hud) {
                 if (!gameInstance.animatronicsActive) break;
 
                 if (anim.posicion === 8) {
+                    if(hud.battery <= 0 && anim.nombre !=="Freddy"){
+                        continue;
+                    }
+
                     console.log(`${anim.nombre} te atrapó!`);
                     gameInstance.setState(gameInstance.GAME_STATES.GAME_OVER);
                     gameInstance.showGameOver(anim.nombre)


### PR DESCRIPTION
## Changes
### HUD
- Removed immediate `GAME_OVER` when battery hits 0.  
- Added `game.onlyFreddyActive` flag to restrict active animatronics after battery depletion.  
- Placeholder for final sound/animation when power runs out.  
- Delayed `GAME_OVER`: Freddy now triggers it after 10s instead of instantly.  

### Animatronics
- Prevented non-Freddy animatronics from killing the player once the battery is depleted.  
- Freddy remains the only animatronic capable of ending the game in this state.  

## Why
- Aligns gameplay closer to FNAF mechanics.  
- Adds tension when power runs out by giving Freddy exclusive control over the game over event.  
- Prepares structure for future sound/animation sequence on power loss.  

## Related
Closes #28