### PR TITLE
Add office intro audio sequence before animatronics start

### DIFF
--- a/public/js/main.js
+++ b/public/js/main.js
@@ -151,7 +151,16 @@ export class game {
         this.hud = new HUD(this);
         this.Office = new Office(this.hud);
 
-        startAnimatronics(this, this.hud);
+        const introAudio = SoundManager.channels.ambience["Office_Intro"];
+
+        if (introAudio) {
+            introAudio.play();
+            SoundManager.once("ambience", "Office_Intro", () =>{
+                startAnimatronics(this, this.hud);
+            })
+        } else {
+            startAnimatronics(this, this.hud);
+        }
     }
 
     showSettings(){

--- a/public/js/sound_manager.js
+++ b/public/js/sound_manager.js
@@ -47,6 +47,10 @@ class SoundManagerClass {
       intro: new Howl({
         src: ["sounds/ambience/intro.mp3"],
         volume: this.volumes.ambience
+      }),
+      Office_Intro: new Howl({
+        src: ["sounds/ambience/intro.mp3"],
+        volume: this.volumes.ambience
       })
     };
 


### PR DESCRIPTION
## Description
This PR introduces an office intro audio sequence that plays when the player
enters the office, before animatronics begin their movement.

### Changes:
- Updated `_onWarningComplete` in `main.js` to play an "Office_Intro" ambience track.
- HUD (battery, time) and office interactions initialize immediately.
- Animatronics remain inactive until the intro audio finishes.
- Added `Office_Intro` entry to the ambience channel in `sound_manager.js`.
- Fallback: if the intro audio is missing, animatronics start immediately.

### Benefits:
- Increases immersion by simulating the introductory call at the start of the night.
- Maintains gameplay flow: HUD and office work normally during the intro.
- Clear separation between game setup and animatronic AI activation.

Closes #38 
